### PR TITLE
added overwrite_existing and only_json_translations options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /nbproject
+/vendor
+/.idea
+/.vscode
+/composer.lock

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -73,4 +73,20 @@ return [
         '__',
         'trans_choice',
     ],
+
+    /*
+      |--------------------------------------------------------------------------
+      | If true - all the keys will be overwritten, even those that are already
+      |--------------------------------------------------------------------------
+      |
+     */
+    'overwrite_existing'   => env('LOCALE_FINDER_OVERWRITE', false),
+
+    /*
+      |--------------------------------------------------------------------------
+      | If true, only JSON keys will be generated; all PHP arrays are skipped
+      |--------------------------------------------------------------------------
+      |
+     */
+    'only_json_translations' => env('LOCALE_FINDER_ONLY_JSON', false),
 ];


### PR DESCRIPTION
The parameters will allow you to disable the forced overwriting of existing keys and avoid translating keys that do not correspond to the JSON format